### PR TITLE
[#12] 태그 조회 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testRuntimeOnly 'com.h2database:h2'
 }
 
 

--- a/src/main/java/capstone/restaurant/controller/TagController.java
+++ b/src/main/java/capstone/restaurant/controller/TagController.java
@@ -2,8 +2,10 @@ package capstone.restaurant.controller;
 
 import capstone.restaurant.dto.ResponseDto;
 import capstone.restaurant.dto.tag.TagListResponse;
+import capstone.restaurant.service.TagService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -11,10 +13,12 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "tags", description = "태그 조회 API")
 @RestController
 @RequestMapping("api/tags")
+@RequiredArgsConstructor
 public class TagController {
+    private final TagService tagService;
     @Operation(summary = "태그 목록 조회", description = "모든 태그 정보를 조회한다.")
     @GetMapping
     public ResponseDto<TagListResponse> getTagList() {
-        return new ResponseDto<>(200, "ok", new TagListResponse());
+        return new ResponseDto<>(200, "ok", tagService.getTags());
     }
 }

--- a/src/main/java/capstone/restaurant/dto/tag/TagListResponse.java
+++ b/src/main/java/capstone/restaurant/dto/tag/TagListResponse.java
@@ -1,6 +1,7 @@
 package capstone.restaurant.dto.tag;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -8,6 +9,7 @@ import java.util.List;
 
 @Getter
 @Setter
+@AllArgsConstructor
 public class TagListResponse {
     private List<TagResponse> tags;
 }

--- a/src/main/java/capstone/restaurant/dto/tag/TagListResponse.java
+++ b/src/main/java/capstone/restaurant/dto/tag/TagListResponse.java
@@ -1,15 +1,15 @@
 package capstone.restaurant.dto.tag;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import java.util.List;
 
 @Getter
 @Setter
 @AllArgsConstructor
+@NoArgsConstructor
+@ToString
 public class TagListResponse {
     private List<TagResponse> tags;
 }

--- a/src/main/java/capstone/restaurant/dto/tag/TagResponse.java
+++ b/src/main/java/capstone/restaurant/dto/tag/TagResponse.java
@@ -5,6 +5,7 @@ import lombok.*;
 
 @Getter
 @Setter
+@AllArgsConstructor
 public class TagResponse {
     @Schema(example = "양식")
     private String name;

--- a/src/main/java/capstone/restaurant/entity/Tag.java
+++ b/src/main/java/capstone/restaurant/entity/Tag.java
@@ -2,11 +2,13 @@ package capstone.restaurant.entity;
 
 
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 @Entity
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 @SequenceGenerator(name = "TAG_SEQ_GEN" , sequenceName = "TAG_SEQUENCE")
 public class Tag {
 

--- a/src/main/java/capstone/restaurant/repository/CategoryRepository.java
+++ b/src/main/java/capstone/restaurant/repository/CategoryRepository.java
@@ -1,0 +1,10 @@
+package capstone.restaurant.repository;
+
+import capstone.restaurant.entity.TagCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CategoryRepository extends JpaRepository<TagCategory, Long> {
+
+}

--- a/src/main/java/capstone/restaurant/repository/TagRepository.java
+++ b/src/main/java/capstone/restaurant/repository/TagRepository.java
@@ -1,0 +1,9 @@
+package capstone.restaurant.repository;
+
+import capstone.restaurant.entity.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TagRepository extends JpaRepository<Tag, Long> {
+}

--- a/src/main/java/capstone/restaurant/service/TagService.java
+++ b/src/main/java/capstone/restaurant/service/TagService.java
@@ -1,0 +1,25 @@
+package capstone.restaurant.service;
+
+import capstone.restaurant.dto.tag.TagListResponse;
+import capstone.restaurant.dto.tag.TagResponse;
+import capstone.restaurant.entity.Tag;
+import capstone.restaurant.repository.TagRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TagService {
+    private final TagRepository tagRepository;
+    public TagListResponse getTags(){
+        List<Tag> tags = tagRepository.findAll();
+
+        List<TagResponse> tagResponseList =  tags.stream().map(tag -> {
+            return new TagResponse(tag.getTagName(), tag.getTagCategory().getCategoryName());
+        }).toList();
+
+        return new TagListResponse(tagResponseList);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,3 +16,9 @@ spring.jpa.hibernate.ddl-auto=none
 #---
 spring.config.activate.on-profile=local
 spring.jpa.hibernate.ddl-auto=update
+#---
+spring.config.activate.on-profile=test
+spring.datasource.url=jdbc:h2:mem:test;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE
+spring.datasource.username=test_user
+spring.datasource.password=1234
+spring.jpa.hibernate.ddl-auto=create-drop

--- a/src/test/java/capstone/restaurant/controller/TagControllerTest.java
+++ b/src/test/java/capstone/restaurant/controller/TagControllerTest.java
@@ -1,0 +1,55 @@
+package capstone.restaurant.controller;
+
+import capstone.restaurant.entity.Tag;
+import capstone.restaurant.entity.TagCategory;
+import capstone.restaurant.repository.CategoryRepository;
+import capstone.restaurant.repository.TagRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class TagControllerTest {
+    @Autowired
+    protected MockMvc mvc;
+    @Autowired
+    protected ObjectMapper objectMapper;
+    @Autowired
+    private TagRepository tagRepository;
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Test
+    void test() throws Exception {
+        // given
+        TagCategory tagCategory = TagCategory.builder().categoryName("category").build();
+        categoryRepository.save(tagCategory);
+        Tag tag = Tag.builder().tagName("tag").tagCategory(tagCategory).build();
+        tagRepository.save(tag);
+
+        // when
+        ResultActions resultActions = mvc.perform(
+                MockMvcRequestBuilders
+                .get("/api/tags")
+                .accept(MediaType.ALL));
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.tags[0].name").value("tag"))
+                .andExpect(jsonPath("$.data.tags[0].category").value("category"));
+    }
+}

--- a/src/test/java/capstone/restaurant/service/TagServiceTest.java
+++ b/src/test/java/capstone/restaurant/service/TagServiceTest.java
@@ -1,0 +1,63 @@
+package capstone.restaurant.service;
+
+import capstone.restaurant.dto.tag.TagListResponse;
+import capstone.restaurant.entity.Tag;
+import capstone.restaurant.entity.TagCategory;
+import capstone.restaurant.repository.TagRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TagServiceTest {
+    @Mock
+    private TagRepository tagRepository;
+    @InjectMocks
+    private TagService tagService;
+
+    @Test
+    @DisplayName("[getTags] 태그 전부 반환")
+    void getTagsTest() {
+        // Given
+        List<Tag> tagList = new ArrayList<>();
+        for ( int i = 0; i < 5; i++ ) {
+            TagCategory tagCategory = TagCategory.builder().categoryName("category" + i).build();
+            tagList.add(Tag.builder()
+                    .tagName("name" + i)
+                    .tagCategory(tagCategory)
+                    .build()
+            );
+        }
+        when(tagRepository.findAll()).thenReturn(tagList);
+
+        //When
+        TagListResponse tags = tagService.getTags();
+
+        //Then
+        assertThat(tags.getTags().get(0).getName()).isEqualTo("name0");
+        assertThat(tags.getTags().get(0).getCategory()).isEqualTo("category0");
+    }
+
+    @Test
+    @DisplayName("[getTags] 태그가 없는 경우 0개 반환")
+    void getTagsTest2() {
+        // Given
+        List<Tag> tagList = new ArrayList<>();
+        when(tagRepository.findAll()).thenReturn(tagList);
+
+        //When
+        TagListResponse tags = tagService.getTags();
+
+        //Then
+        assertThat(tags.getTags().size()).isEqualTo(0);
+    }
+}


### PR DESCRIPTION
## 이슈
- #12

## 체크리스트
- [x] 전체 태그 목록을 조회하는 기능 구현
- [x] 전체 태그 목록을 조회하는 기능 테스트

## 고민한 내용
### 태그 조회 기능
- 모든 태그과 해당 태그가 속한 카테고리도 같이 조회 할 수 있도록 구현.

### 단위 테스트
- 우선 service 레이어의 코드는 단위 테스트로 구현
  - repository 를 모킹해서 테스트 진행
### 통합테스트
- 태그 조회 api 에 대한 통합테스트는 @SpringBootTest 를 이용해 구현
- test 프로필을 추가해서 @SpringBootTest가 돌아갈 때는 test 프로필을 적용하도록 했다.
- DB 는 H2 를 사용했다. 

### DTO와 엔티티의 어노테이션 통일 문제
- 각 DTO와 엔티티 마다 다 다르게 설정 되어있어서 통일이 필요할듯 싶은데 어떻게 생각하시는지요?
