### PR TITLE
[#47] Logger 재설정

### DIFF
--- a/src/main/java/capstone/restaurant/filter/HttpRequestWrapperFilter.java
+++ b/src/main/java/capstone/restaurant/filter/HttpRequestWrapperFilter.java
@@ -1,13 +1,22 @@
 package capstone.restaurant.filter;
 
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+import java.io.IOException;
 
 @Slf4j
 @Component
-public class HttpRequestWrapperFilter {
+public class HttpRequestWrapperFilter implements Filter {
 
-
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        ContentCachingRequestWrapper httpRequest = new ContentCachingRequestWrapper((HttpServletRequest) servletRequest);
+        filterChain.doFilter(httpRequest , servletResponse);
+    }
 }
 
 

--- a/src/main/java/capstone/restaurant/filter/HttpRequestWrapperFilter.java
+++ b/src/main/java/capstone/restaurant/filter/HttpRequestWrapperFilter.java
@@ -1,0 +1,13 @@
+package capstone.restaurant.filter;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class HttpRequestWrapperFilter {
+
+
+}
+
+

--- a/src/main/java/capstone/restaurant/interceptor/LoggerInterceptor.java
+++ b/src/main/java/capstone/restaurant/interceptor/LoggerInterceptor.java
@@ -1,29 +1,33 @@
 package capstone.restaurant.interceptor;
 
+import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.servlet.DispatcherServlet;
 import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+import java.util.stream.Stream;
 
 @Slf4j
 @Component
 public class LoggerInterceptor implements HandlerInterceptor {
 
     @Override
-    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
-        log.info("URL : {} , method : {} , body : {}" , request.getRequestURL() , request.getMethod());
-        return true;
-    }
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler , Exception ex) throws Exception {
 
-    @Override
-    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) throws Exception {
-        if(ex != null){
-            log.error("에러 발생");
+        ContentCachingRequestWrapper requestInfo = (ContentCachingRequestWrapper) request;
+        String requestBody = requestInfo.getContentAsString();
+
+        if(200 <= response.getStatus() && response.getStatus() < 300){
+            log.info("url = {} , method = {} , body = {}" , request.getRequestURL() , request.getMethod() , requestBody);
         }else{
-            log.info("에러 없음");
+            log.error("url = {} , method = {} , status = {} ,  body = {}" , request.getRequestURL() , request.getMethod() , response.getStatus() , requestBody);
         }
     }
 }
+


### PR DESCRIPTION
## 이슈
- #47 

## 체크리스트
- [x] 로그가 2번 찍히는 문제 해결
- [x] 로그에 body 정보도 함께 기록

## 고민한 내용
- RequestBody 는 stream 이므로 한번 밖에 소비되지 못한다. 이 문제를 해결해야 했음
   -  fitler 를 추가해서 dispatcherServlet 에 들어오기 전에 request 를 ContentWrapper 클래스로 변환하여 해결
   - 위 과정을 interceptor 의 preHandle 을 통해 처리할 수 있을까 고민했는데 해당 방법은 찾지 못했다.
  
- ArguementResolver 를 통해 처리된 exception 은 interceptor 의 afterCompletion 까지 전파되지 않는다
   - ControllerAdvice 에서 처리된 exception 들은 더 이상 전파되지 않는다. interceptor 의 afterCompletion 은 controllerAdvice 가 실행된 이후에 수행되므로 exception 이 전파되지 않음
   - response status 를 통해 로그를 나눠서 작성하는 방법으로 구현
