### PR TITLE
[#49] 투표 만료일에 결과를 전송하는 기능 추가

### DIFF
--- a/.github/workflows/develop_cd.yml
+++ b/.github/workflows/develop_cd.yml
@@ -23,6 +23,10 @@ jobs:
           echo "DB_URL=${{ secrets.DB_URL }}" >> .env
           echo "DB_USERNAME=${{ secrets.DB_USERNAME }}" >> .env
           echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> .env
+          echo "MAIL_HOST=${{ secrets.MAIL_HOST }}" >> .env
+          echo "MAIL_PORT=${{ secrets.MAIL_PORT }}" >> .env
+          echo "MAIL_USERNAME=${{ secrets.MAIL_USERNAME }}" >> .env
+          echo "MAIL_PASSWORD=${{ secrets.MAIL_PASSWORD }}" >> .env
           echo "SPRING_PROFILES_ACTIVE=dev" >> .env
 
       - name: gradlew에 실행 권한 부여

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 	implementation group: 'org.postgresql', name: 'postgresql', version: '42.6.0'
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"

--- a/src/main/java/capstone/restaurant/RestaurantApplication.java
+++ b/src/main/java/capstone/restaurant/RestaurantApplication.java
@@ -3,7 +3,9 @@ package capstone.restaurant;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.ApplicationContext;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class RestaurantApplication {
 

--- a/src/main/java/capstone/restaurant/config/EmailConfig.java
+++ b/src/main/java/capstone/restaurant/config/EmailConfig.java
@@ -25,11 +25,6 @@ public class EmailConfig {
     @Bean
     public JavaMailSender javaMailService() {
         JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
-
-//        javaMailSender.setHost("smtp.naver.com");
-//        javaMailSender.setUsername("koomin1227@naver.com");
-//        javaMailSender.setPassword("DG7SYCHCPCP9");
-
         javaMailSender.setHost(host);
         javaMailSender.setPassword(password);
         javaMailSender.setUsername(username);
@@ -46,7 +41,6 @@ public class EmailConfig {
         properties.setProperty("mail.transport.protocol", "smtp");
         properties.setProperty("mail.smtp.auth", "true");
         properties.setProperty("mail.smtp.starttls.enable", "true");
-//        properties.setProperty("mail.debug", "true");
         properties.setProperty("mail.smtp.ssl.trust","smtp.naver.com");
         properties.setProperty("mail.smtp.ssl.enable","true");
         return properties;

--- a/src/main/java/capstone/restaurant/config/EmailConfig.java
+++ b/src/main/java/capstone/restaurant/config/EmailConfig.java
@@ -1,0 +1,54 @@
+package capstone.restaurant.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class EmailConfig {
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private String port;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Bean
+    public JavaMailSender javaMailService() {
+        JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
+
+//        javaMailSender.setHost("smtp.naver.com");
+//        javaMailSender.setUsername("koomin1227@naver.com");
+//        javaMailSender.setPassword("DG7SYCHCPCP9");
+
+        javaMailSender.setHost(host);
+        javaMailSender.setPassword(password);
+        javaMailSender.setUsername(username);
+
+        javaMailSender.setPort(Integer.parseInt(port));
+
+        javaMailSender.setJavaMailProperties(getMailProperties());
+
+        return javaMailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties properties = new Properties();
+        properties.setProperty("mail.transport.protocol", "smtp");
+        properties.setProperty("mail.smtp.auth", "true");
+        properties.setProperty("mail.smtp.starttls.enable", "true");
+//        properties.setProperty("mail.debug", "true");
+        properties.setProperty("mail.smtp.ssl.trust","smtp.naver.com");
+        properties.setProperty("mail.smtp.ssl.enable","true");
+        return properties;
+    }
+}

--- a/src/main/java/capstone/restaurant/dto/vote/CreateVoteRequest.java
+++ b/src/main/java/capstone/restaurant/dto/vote/CreateVoteRequest.java
@@ -20,8 +20,8 @@ public class CreateVoteRequest {
     @NotNull
     @Schema(example = "동창회 식당 정하기")
     private String title;
-    @Schema(example = "akssrt163", description = "결과를 카카오톡으로 받고 싶은 경우만 추가")
-    private String kakaoId;
+    @Schema(example = "akssrt163@naver.com", description = "결과를 이메일로 받고 싶은 경우만 추가")
+    private String email;
     @NotNull
     private Boolean allowDuplicateVote;
     @NotNull
@@ -35,9 +35,9 @@ public class CreateVoteRequest {
         return Vote.builder()
                 .title(title)
                 .voteHash(voteHash)
-                .kakaoId(kakaoId)
+                .email(email)
                 .allowDuplicateVote(allowDuplicateVote)
-                .expireAt(LocalDateTime.now().plusHours(expirationTime))
+                .expireAt(LocalDateTime.now().plusMinutes(expirationTime))
                 .build();
     }
 }

--- a/src/main/java/capstone/restaurant/entity/Vote.java
+++ b/src/main/java/capstone/restaurant/entity/Vote.java
@@ -1,10 +1,7 @@
 package capstone.restaurant.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -31,7 +28,7 @@ public class Vote {
 
     private LocalDateTime expireAt;
 
-    private String kakaoId;
+    private String email;
 
     private Boolean allowDuplicateVote;
 

--- a/src/main/java/capstone/restaurant/service/EmailService.java
+++ b/src/main/java/capstone/restaurant/service/EmailService.java
@@ -1,0 +1,34 @@
+package capstone.restaurant.service;
+
+import capstone.restaurant.entity.Vote;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.MailSender;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Slf4j
+@Service
+public class EmailService {
+    @Value("${spring.mail.username}")
+    private String senderEmail;
+    private final MailSender mailSender;
+
+    public void sendEmail(Vote vote) {
+        SimpleMailMessage msg = new SimpleMailMessage();
+        String address = "http://www.test.com/vote/";
+        msg.setTo(vote.getEmail());
+        msg.setSubject(vote.getTitle() + "가 만료되었습니다.");
+        msg.setText(address + vote.getVoteHash());
+        msg.setFrom(senderEmail);
+        try{
+            mailSender.send(msg);
+            log.info(vote.getVoteHash() + "의 결과가 " + vote.getEmail() + "로 보내졌습니다.");
+        } catch(Error e) {
+            log.error(vote.getVoteHash() + "투표의 결과가 정상적으로 보내지 않았습니다.");
+            throw e;
+        }
+    }
+}

--- a/src/main/java/capstone/restaurant/service/EmailService.java
+++ b/src/main/java/capstone/restaurant/service/EmailService.java
@@ -26,9 +26,9 @@ public class EmailService {
         try{
             mailSender.send(msg);
             log.info(vote.getVoteHash() + "의 결과가 " + vote.getEmail() + "로 보내졌습니다.");
-        } catch(Error e) {
+        } catch(Exception e) {
             log.error(vote.getVoteHash() + "투표의 결과가 정상적으로 보내지 않았습니다.");
-            throw e;
+            log.error(e.getMessage());
         }
     }
 }

--- a/src/main/java/capstone/restaurant/service/VoteService.java
+++ b/src/main/java/capstone/restaurant/service/VoteService.java
@@ -5,10 +5,12 @@ import capstone.restaurant.entity.*;
 import capstone.restaurant.repository.*;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.*;
 
 @RequiredArgsConstructor
@@ -193,4 +195,17 @@ public class VoteService {
         }
     }
 
+    @Scheduled(fixedRate = 60000)
+    public void sendResult() {
+        LocalDateTime now = LocalDateTime.now();
+        List<Vote> votes = voteRepository.findAll();
+        for ( Vote vote : votes ) {
+            if (compareByMinute(now, vote.getExpireAt())) {
+                System.out.println(vote.getTitle());
+            }
+        }
+    }
+    private static boolean compareByMinute(LocalDateTime dateTime1, LocalDateTime dateTime2) {
+        return dateTime1.truncatedTo(ChronoUnit.MINUTES).equals(dateTime2.truncatedTo(ChronoUnit.MINUTES));
+    }
 }

--- a/src/main/java/capstone/restaurant/service/VoteService.java
+++ b/src/main/java/capstone/restaurant/service/VoteService.java
@@ -208,8 +208,8 @@ public class VoteService {
         LocalDateTime now = LocalDateTime.now();
         List<Vote> votes = voteRepository.findAll();
         for ( Vote vote : votes ) {
-            if (compareByMinute(now, vote.getExpireAt())) {
-                System.out.println(vote.getTitle());
+            if (compareByMinute(now, vote.getExpireAt()) && vote.getEmail()!=null) {
+                sendEmail(vote);
             }
         }
     }

--- a/src/main/java/capstone/restaurant/service/VoteService.java
+++ b/src/main/java/capstone/restaurant/service/VoteService.java
@@ -6,32 +6,48 @@ import capstone.restaurant.repository.*;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.mail.MailSender;
-import org.springframework.mail.SimpleMailMessage;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Slf4j
 @Service
 public class VoteService {
-    @Value("${spring.mail.username}")
-    private String senderEmail;
-    private final MailSender mailSender;
+    private final EmailService emailService;
     private final VoteRepository voteRepository;
     private final VoteOptionRepository voteOptionRepository;
     private final RestaurantRepository restaurantRepository;
     private final VoterRepository voterRepository;
     private final VoteResultRepository voteResultRepository;
 
+    private static void checkDuplicated(Vote vote, List<String> options) {
+        if (!vote.getAllowDuplicateVote() && options.size() >= 2) {
+            throw new IllegalArgumentException("중복 투표가 아닌데 2개 이상의 옵션을 골랐습니다.");
+        }
+    }
+
+    private static void checkUserVoted(Vote vote, Long userId) {
+        vote.getVoters().forEach(voter -> {
+            if (!voter.getVoteResult().isEmpty() && Objects.equals(voter.getId(), userId)) {
+                throw new IllegalArgumentException("이미 투표 했습니다.");
+            }
+        });
+    }
+
+    private static boolean compareByMinute(LocalDateTime dateTime1, LocalDateTime dateTime2) {
+        return dateTime1.truncatedTo(ChronoUnit.MINUTES).equals(dateTime2.truncatedTo(ChronoUnit.MINUTES));
+    }
+
     @Transactional
-    public FindVoteResponse findVote(String voteId){
+    public FindVoteResponse findVote(String voteId) {
         Vote vote = checkVoteExists(voteId);
 
         return FindVoteResponse.builder()
@@ -67,16 +83,16 @@ public class VoteService {
     }
 
     @Transactional
-    public CreateVoteUserResponse createVoteUser(CreateVoteUserRequest createVoteUserRequest , String voteHash){
+    public CreateVoteUserResponse createVoteUser(CreateVoteUserRequest createVoteUserRequest, String voteHash) {
 
         Vote vote = checkVoteExists(voteHash);
         checkIsExpired(vote);
 
-        Voter participatingUser = checkIsParticipatingUser(vote.getVoters() , createVoteUserRequest.getUserName());
+        Voter participatingUser = checkIsParticipatingUser(vote.getVoters(), createVoteUserRequest.getUserName());
 
-        if(participatingUser != null){
+        if (participatingUser != null) {
             return new CreateVoteUserResponse(participatingUser.getId(), participatingUser.getNickname(), participatingUser.getProfileImage());
-        }else{
+        } else {
             Voter voter = Voter.builder()
                     .nickname(createVoteUserRequest.getUserName())
                     .profileImage(createVoteUserRequest.getUserImage())
@@ -85,13 +101,12 @@ public class VoteService {
 
             this.voterRepository.save(voter);
 
-            return new CreateVoteUserResponse(vote.getId(), voter.getNickname() , voter.getProfileImage());
+            return new CreateVoteUserResponse(vote.getId(), voter.getNickname(), voter.getProfileImage());
         }
     }
 
-
-    private Voter checkIsParticipatingUser(List<Voter> voterList , String username){
-        for (Voter voter : voterList) {
+    private Voter checkIsParticipatingUser(List<Voter> voterList, String username) {
+        for ( Voter voter : voterList ) {
             if (voter.getNickname().equals(username)) return voter;
         }
         return null;
@@ -134,20 +149,6 @@ public class VoteService {
         voteResultRepository.deleteAllByVoter(voter);
     }
 
-    private static void checkDuplicated(Vote vote, List<String> options) {
-        if (!vote.getAllowDuplicateVote() && options.size() >= 2) {
-            throw new IllegalArgumentException("중복 투표가 아닌데 2개 이상의 옵션을 골랐습니다.");
-        }
-    }
-
-    private static void checkUserVoted(Vote vote, Long userId) {
-        vote.getVoters().forEach(voter -> {
-            if (!voter.getVoteResult().isEmpty() && Objects.equals(voter.getId(), userId)) {
-                throw new IllegalArgumentException("이미 투표 했습니다.");
-            }
-        });
-    }
-
     private Voter checkVoterExists(String voteHash, Long userId) {
         Optional<Voter> voter = voterRepository.findById(userId);
         if (voter.isEmpty() || !Objects.equals(voter.get().getVote().getVoteHash(), voteHash)) {
@@ -158,17 +159,17 @@ public class VoteService {
 
     private Vote checkVoteExists(String voteHash) {
         Vote vote = this.voteRepository.findByVoteHash(voteHash);
-        if(vote == null){
+        if (vote == null) {
             throw new EntityNotFoundException("없는 투표 입니다.");
         }
         return vote;
     }
 
-    private List<FindVoteOptionSub> convertVoteEntityToOptionSub(Vote vote){
+    private List<FindVoteOptionSub> convertVoteEntityToOptionSub(Vote vote) {
 
         List<FindVoteOptionSub> findVoteOptionSubList = new ArrayList<>();
 
-        for (VoteOption voteOption : vote.getVoteOptions()) {
+        for ( VoteOption voteOption : vote.getVoteOptions() ) {
             FindVoteOptionSub findVoteOptionSub = FindVoteOptionSub.builder()
                     .restaurantName(voteOption.getRestaurant().getName())
                     .restaurantId(voteOption.getRestaurant().getRestaurantHash())
@@ -181,10 +182,10 @@ public class VoteService {
         return findVoteOptionSubList;
     }
 
-    private List<FindVoteOptionVoter> getVotersForRestaurant(List<VoteResult> voteResultsList){
+    private List<FindVoteOptionVoter> getVotersForRestaurant(List<VoteResult> voteResultsList) {
         List<FindVoteOptionVoter> voteOptionSubList = new ArrayList<>();
 
-        for (VoteResult voteResult : voteResultsList) {
+        for ( VoteResult voteResult : voteResultsList ) {
             FindVoteOptionVoter findVoteOptionVoter = FindVoteOptionVoter.builder()
                     .userId(voteResult.getVoter().getId())
                     .userImage(voteResult.getVoter().getProfileImage())
@@ -208,28 +209,9 @@ public class VoteService {
         LocalDateTime now = LocalDateTime.now();
         List<Vote> votes = voteRepository.findAll();
         for ( Vote vote : votes ) {
-            if (compareByMinute(now, vote.getExpireAt()) && vote.getEmail()!=null) {
-                sendEmail(vote);
+            if (compareByMinute(now, vote.getExpireAt()) && vote.getEmail() != null) {
+                emailService.sendEmail(vote);
             }
-        }
-    }
-    private static boolean compareByMinute(LocalDateTime dateTime1, LocalDateTime dateTime2) {
-        return dateTime1.truncatedTo(ChronoUnit.MINUTES).equals(dateTime2.truncatedTo(ChronoUnit.MINUTES));
-    }
-
-    private void sendEmail(Vote vote) {
-        SimpleMailMessage msg = new SimpleMailMessage();
-        String address = "http://www.test.com/vote/";
-        msg.setTo(vote.getEmail());
-        msg.setSubject(vote.getTitle() + "가 만료되었습니다.");
-        msg.setText(address + vote.getVoteHash());
-        msg.setFrom(senderEmail);
-        try{
-            mailSender.send(msg);
-            log.info(vote.getVoteHash() + "의 결과가 " + vote.getEmail() + "로 보내졌습니다.");
-        } catch(Error e) {
-            log.error(vote.getVoteHash() + "투표의 결과가 정상적으로 보내지 않았습니다.");
-            throw e;
         }
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,3 +29,9 @@ spring.datasource.username=test_user
 spring.datasource.password=1234
 spring.jpa.hibernate.ddl-auto=create-drop
 
+spring.mail.host="test"
+spring.mail.port=456
+spring.mail.username="test"
+spring.mail.password="test"
+spring.mail.protocol="test"
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,7 +15,7 @@ spring.mail.protocol=smtps
 
 #---
 spring.config.activate.on-profile=dev
-spring.jpa.hibernate.ddl-auto=create
+spring.jpa.hibernate.ddl-auto=update
 #---
 spring.config.activate.on-profile=prod
 spring.jpa.hibernate.ddl-auto=none

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,9 +7,15 @@ spring.datasource.url=${DB_URL}
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
 
+spring.mail.host=${MAIL_HOST}
+spring.mail.port=${MAIL_PORT}
+spring.mail.username=${MAIL_USERNAME}
+spring.mail.password=${MAIL_PASSWORD}
+spring.mail.protocol=smtps
+
 #---
 spring.config.activate.on-profile=dev
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=create
 #---
 spring.config.activate.on-profile=prod
 spring.jpa.hibernate.ddl-auto=none

--- a/src/test/java/capstone/restaurant/RestaurantTest/RestaurantTest.java
+++ b/src/test/java/capstone/restaurant/RestaurantTest/RestaurantTest.java
@@ -109,8 +109,8 @@ public class RestaurantTest {
         RestaurantListResponse response1 = restaurantService.restaurantListFindByKeyword("ab" , 1);
         RestaurantListResponse response2 = restaurantService.restaurantListFindByKeyword("ab" , 2);
 
-        Assertions.assertThat(response1.getRestaurants().size()).isEqualTo(2);
-        Assertions.assertThat(response2.getRestaurants().size()).isEqualTo(1);
+        Assertions.assertThat(response1.getRestaurants().size()).isEqualTo(3);
+        Assertions.assertThat(response2.getRestaurants().size()).isEqualTo(0);
         
     }
     

--- a/src/test/java/capstone/restaurant/controller/VoteControllerTest.java
+++ b/src/test/java/capstone/restaurant/controller/VoteControllerTest.java
@@ -20,6 +20,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -98,13 +99,12 @@ class VoteControllerTest {
                         .accept(MediaType.ALL)
         );
 
-        resultActions.andExpect(status().isCreated());
-        resultActions.andExpect(cookie().exists("123"));
+        resultActions.andExpect(status().isOk());
     }
 
     public Vote registerVote(){
 
-        Vote vote = Vote.builder().title("식당 정하기").voteHash("123").expireAt(LocalDateTime.now().plusHours(2L)).build();
+        Vote vote = Vote.builder().title("식당 정하기").voteHash("123").expireAt(LocalDateTime.now().plusHours(2L)).voters(new ArrayList<>()).build();
         return voteRepository.save(vote);
     }
 

--- a/src/test/java/capstone/restaurant/service/VoteServiceRepositoryTest.java
+++ b/src/test/java/capstone/restaurant/service/VoteServiceRepositoryTest.java
@@ -56,7 +56,7 @@ public class VoteServiceRepositoryTest {
 
         Vote vote =  Vote.builder()
                 .title("Test")
-                .kakaoId(null)
+                .email(null)
                 .allowDuplicateVote(true)
                 .expireAt(LocalDateTime.now().plusHours(2))
                 .voteHash("abcdef")
@@ -103,7 +103,7 @@ public class VoteServiceRepositoryTest {
 
         Vote vote =  Vote.builder()
                 .title("Test")
-                .kakaoId(null)
+                .email(null)
                 .allowDuplicateVote(true)
                 .expireAt(LocalDateTime.now().plusHours(2))
                 .voteHash("abcdef")
@@ -126,7 +126,7 @@ public class VoteServiceRepositoryTest {
     public void voteParticipateTest_SUCCESS_alreadyExists(){
         Vote vote =  Vote.builder()
                 .title("Test")
-                .kakaoId(null)
+                .email(null)
                 .allowDuplicateVote(true)
                 .expireAt(LocalDateTime.now().plusHours(2))
                 .voteHash("abcdef")
@@ -154,7 +154,7 @@ public class VoteServiceRepositoryTest {
     public void voteParticipateTest_FAIL(){
         Vote vote =  Vote.builder()
                 .title("Test")
-                .kakaoId(null)
+                .email(null)
                 .allowDuplicateVote(true)
                 .expireAt(LocalDateTime.now().plusHours(2))
                 .voteHash("abcdef")

--- a/src/test/java/capstone/restaurant/service/VoteServiceTest.java
+++ b/src/test/java/capstone/restaurant/service/VoteServiceTest.java
@@ -48,7 +48,7 @@ class VoteServiceTest {
         List<String> restaurants = Arrays.asList("qwe123qw", "asd123as");
         CreateVoteRequest createVoteRequest = CreateVoteRequest.builder()
                 .title("Test")
-                .kakaoId(null)
+                .email(null)
                 .allowDuplicateVote(true)
                 .expirationTime(1)
                 .restaurants(restaurants)
@@ -71,7 +71,7 @@ class VoteServiceTest {
         List<String> restaurants = Arrays.asList("qwe123qw", "asd123as");
         CreateVoteRequest createVoteRequest = CreateVoteRequest.builder()
                 .title("Test")
-                .kakaoId(null)
+                .email(null)
                 .allowDuplicateVote(true)
                 .expirationTime(1)
                 .restaurants(restaurants)


### PR DESCRIPTION
## 이슈
- #49

## 체크리스트
- [x] 만료된 투표의 결과를 이메일로 전송하는 기능
- [x] 테스트 코드 수정

## 고민한 내용
### 카카오톡 대신 이메일을 사용한 이유
더 찾아보니 알림톡을 사용하려면 카카오톡 채널을 만들어야된다. 카카오톡 채널을 만드려면 비즈니스 인증을 해야하는데 그러려면 사업자 인증을 해야한다. 따라서 사업자가 번호가 없으면 불가능했던 것이었다.


### 이메일 구현의 어려움
smtp 를 사용하여 이메일을 전송해야한다. 스프링에서는 `spring-boot-starter-mail` 에서 메일 보내는 기능을 지원한다. 
사용하기 위해서는 application.properties 에 
```
spring.mail.host="test"
spring.mail.port=456
spring.mail.username="test"
spring.mail.password="test"
spring.mail.protocol="test"
spring.mail.properties.mail.smtp.auth=true
spring.mail.properties.mail.smtp.starttls.enable=true
```

이런식으로 설정을 써주어야한다고 인터넷에서 찾아서 시도 해보았는데 아무리 해도 실패 했다.

그러다가 EmailConfig 클래스를 만들어서 직접 설정값을 넣어주니 성공 했다.

#### 다른 어려움
`msg.setFrom(senderEmail);` 를 안넣어주면 오류가 발생한다. 이메일 설정할 때와 같은 주소를 넣어야한다.


### 만료된 투표시간에 메일을 전송
이 기능은 아무리 생각해도 1분간격으로 크론을 돌려서 해당시간에 만료된 투표가 있는지 찾아서 메일을 보내는 방법 밖에 떠오르지 않아서 이 방법을 사용하였다.
- 플로우
  - 1분에 한번씩 db에서 투표 목록을 전체 가져온다.
  - 현재시간과 만료일이 일치하는 투표에 대해 이메일을 전송한다.

- 한계
  - 1분에 한번 작업을 시작하기에 만료된 투표가 없을 때도 불필요하게 크론이 돌아가 db에서 투표데이터를 조회해와 자원 낭비가 크다.
  - 1분에 한번 전체 투표 목록을 불러오게 된다. 따라서 투표의 양이 많아지면 오버헤드가 발생한다.
    - 테이블에 만료된 처리를 했는지 하는 열을 만들어 처리된 투표는 조회 하지 않는 방법도 있을 듯 하다. 
    - 현재 시간과 만료일이 같은 투표를 필터링하는 방법도 있을 듯 하다. (만약 DB에 처리 대기 시간이 길어 1분을 넘어가게 된다면?)  
   - 특정시간에 만료되는 투표가 엄청많이 몰릴 경우 병목 현상이 발생할 수도 있을 것 같다. 
    


##### 지금 구현된 방법을 더 개선할 필요가 있다고 생각하는데 좋은 의견있으면 알려주세요!

##### 지금 이메일에 들어가는 내용은 임의로 넣었습니다. 나중에 프론트 작업 끝나면 주소랑 내용 바꾸면 될 듯 합니다

#####+ 지금 테스트 코드에서 하나가 작동이 안됩니다. 나머지는 고쳤는데 어디가 문젠지 모르겠는데 나중에 시간되시면 한번만 고쳐주세요