### PR TITLE
투표 만료시 전송되는 이메일 내용 변경 및 랜덤으로 식당을 뽑는 기능 구현

### DIFF
--- a/src/main/java/capstone/restaurant/controller/RestaurantController.java
+++ b/src/main/java/capstone/restaurant/controller/RestaurantController.java
@@ -3,7 +3,6 @@ package capstone.restaurant.controller;
 import capstone.restaurant.dto.ResponseDto;
 import capstone.restaurant.dto.restaurant.RestaurantListResponse;
 import capstone.restaurant.dto.restaurant.RestaurantResponse;
-import capstone.restaurant.dto.tag.TagListResponse;
 import capstone.restaurant.service.RestaurantService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -14,8 +13,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 import org.springframework.web.bind.annotation.*;
-
-import java.awt.print.Pageable;
 
 @Tag(name = "restaurants", description = "식당 조회 API")
 @RestController
@@ -37,7 +34,7 @@ public class RestaurantController {
 
         if(page <= 0) throw new IllegalArgumentException("page 는 0보다 큰 정수이어야 합니다");
 
-        RestaurantListResponse restaurantListResponse = this.restaurantService.restaurantListFindByTag(place , tags  , page);
+        RestaurantListResponse restaurantListResponse = this.restaurantService.findRestaurantListByTag(place , tags  , page);
         restaurantService.findRandomRestaurant();
         return new ResponseDto<>(200, "ok", restaurantListResponse);
 
@@ -52,7 +49,7 @@ public class RestaurantController {
 
         if(page <= 0) throw new IllegalArgumentException("page 는 0보다 큰 정수이어야 합니다");
 
-        RestaurantListResponse restaurantListResponse=  this.restaurantService.restaurantListFindByKeyword(keyword , page);
+        RestaurantListResponse restaurantListResponse=  this.restaurantService.findRestaurantListByKeyword(keyword , page);
 
         return new ResponseDto<>(200, "ok" , restaurantListResponse);
     }
@@ -70,7 +67,7 @@ public class RestaurantController {
     @ResponseStatus(HttpStatus.OK)
     @ApiResponses(value = { @ApiResponse(responseCode = "200" , description = "id 로 상세 레스토랑 정보 반환") , @ApiResponse(responseCode = "404" , description = "식당을 찾을 수 없음")})
     public ResponseDto<RestaurantResponse> getRestaurant(@PathVariable String id) {
-        RestaurantResponse restaurantResponse = this.restaurantService.restaurantFindById(id);
+        RestaurantResponse restaurantResponse = this.restaurantService.findRestaurantById(id);
         return new ResponseDto<>(200, "ok", restaurantResponse);
     }
 }

--- a/src/main/java/capstone/restaurant/controller/RestaurantController.java
+++ b/src/main/java/capstone/restaurant/controller/RestaurantController.java
@@ -38,7 +38,7 @@ public class RestaurantController {
         if(page <= 0) throw new IllegalArgumentException("page 는 0보다 큰 정수이어야 합니다");
 
         RestaurantListResponse restaurantListResponse = this.restaurantService.restaurantListFindByTag(place , tags  , page);
-
+        restaurantService.findRandomRestaurant();
         return new ResponseDto<>(200, "ok", restaurantListResponse);
 
     }
@@ -55,6 +55,14 @@ public class RestaurantController {
         RestaurantListResponse restaurantListResponse=  this.restaurantService.restaurantListFindByKeyword(keyword , page);
 
         return new ResponseDto<>(200, "ok" , restaurantListResponse);
+    }
+    @Operation(summary = "식당 랜덤 조회", description = "랜덤으로 식당하나를 뽑아서 응답한다.")
+    @GetMapping("/random")
+    @ResponseStatus(HttpStatus.OK)
+    @ApiResponses(value = { @ApiResponse(responseCode = "200" , description = "랜덤 레스토랑 정보 반환") , @ApiResponse(responseCode = "404" , description = "식당을 찾을 수 없음")})
+    public ResponseDto<RestaurantResponse> getRestaurantRandom() {
+        RestaurantResponse restaurantResponse = this.restaurantService.findRandomRestaurant();
+        return new ResponseDto<>(200, "ok", restaurantResponse);
     }
 
     @Operation(summary = "식당 상세 조회", description = "식당의 상세정보를 조회한다.")

--- a/src/main/java/capstone/restaurant/entity/Restaurant.java
+++ b/src/main/java/capstone/restaurant/entity/Restaurant.java
@@ -1,5 +1,8 @@
 package capstone.restaurant.entity;
 
+import capstone.restaurant.dto.restaurant.RestaurantResponse;
+import capstone.restaurant.dto.restaurant.ReviewListSub;
+import capstone.restaurant.dto.tag.TagResponse;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -40,5 +43,24 @@ public class Restaurant {
     @Builder.Default
     @OneToMany(mappedBy = "restaurant")
     private  List<Review> reviews = new ArrayList<>();
+
+    public static RestaurantResponse toDto(Restaurant restaurant) {
+//        List<TagResponse> tagResponseList = new ArrayList<TagResponse>();
+//
+//        for (RestaurantTag restaurantTag : restaurant.getRestaurantTag()) {
+//            tagResponseList.add(new TagResponse(restaurantTag.getTag().getTagName() , restaurantTag.getTag().getTagCategory().getCategoryName()));
+//        }
+
+        List<TagResponse> tagResponseList = restaurant.getRestaurantTag()
+                .stream().map(restaurantTag -> Tag.toDto(restaurantTag.getTag())).toList();
+
+        List<ReviewListSub> reviewList = Review.toDtoList(restaurant.getReviews());
+
+//        for (Review review : restaurant.getReviews()){
+//            reviewList.add(new ReviewListSub(review.getReview() , review.getIsAiReview()));
+//        }
+
+        return new RestaurantResponse(restaurant.getName() , restaurant.getThumbnail() , tagResponseList , restaurant.getRestaurantHash() , reviewList);
+    }
 
 }

--- a/src/main/java/capstone/restaurant/entity/Review.java
+++ b/src/main/java/capstone/restaurant/entity/Review.java
@@ -1,9 +1,12 @@
 package capstone.restaurant.entity;
 
+import capstone.restaurant.dto.restaurant.ReviewListSub;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+
+import java.util.List;
 
 @Entity
 @Getter
@@ -22,4 +25,12 @@ public class Review {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "restaurant_id")
     private Restaurant restaurant;
+
+    public static ReviewListSub toDto(Review review) {
+        return new ReviewListSub(review.getReview() , review.getIsAiReview());
+    }
+
+    public static List<ReviewListSub> toDtoList(List<Review> reviews) {
+        return reviews.stream().map(Review::toDto).toList();
+    }
 }

--- a/src/main/java/capstone/restaurant/entity/Tag.java
+++ b/src/main/java/capstone/restaurant/entity/Tag.java
@@ -1,6 +1,7 @@
 package capstone.restaurant.entity;
 
 
+import capstone.restaurant.dto.tag.TagResponse;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -22,4 +23,11 @@ public class Tag {
     @JoinColumn(name="tag_category_id")
     private TagCategory tagCategory;
 
+    public static TagResponse toDto(Tag tag) {
+        return new TagResponse(tag.getTagName(), tag.getTagCategory().getCategoryName());
+    }
+
+//    public TagResponse toDtoList(List<Tag> tag) {
+//        return new TagResponse(tag.getTagName(), tag.getTagCategory().getCategoryName());
+//    }
 }

--- a/src/main/java/capstone/restaurant/repository/RestaurantRepository.java
+++ b/src/main/java/capstone/restaurant/repository/RestaurantRepository.java
@@ -4,10 +4,13 @@ import capstone.restaurant.entity.Restaurant;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RestaurantRepository extends JpaRepository<Restaurant, Long> , RestaurantRepositoryCustom {
+    @Query(value = "SELECT * FROM Restaurant ORDER BY RANDOM() LIMIT 1", nativeQuery = true)
+    Restaurant findRandomRestaurant();
 
     Page<Restaurant> findRestaurantsByNameContaining(String name , Pageable pageable);
 

--- a/src/main/java/capstone/restaurant/service/EmailService.java
+++ b/src/main/java/capstone/restaurant/service/EmailService.java
@@ -1,12 +1,17 @@
 package capstone.restaurant.service;
 
 import capstone.restaurant.entity.Vote;
+import capstone.restaurant.entity.VoteOption;
+import capstone.restaurant.entity.Voter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.MailSender;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Slf4j
@@ -21,7 +26,7 @@ public class EmailService {
         String address = "http://www.test.com/vote/";
         msg.setTo(vote.getEmail());
         msg.setSubject(vote.getTitle() + "가 만료되었습니다.");
-        msg.setText(address + vote.getVoteHash());
+        msg.setText(generateEmailBody(vote));
         msg.setFrom(senderEmail);
         try{
             mailSender.send(msg);
@@ -30,5 +35,26 @@ public class EmailService {
             log.error(vote.getVoteHash() + "투표의 결과가 정상적으로 보내지 않았습니다.");
             log.error(e.getMessage());
         }
+    }
+
+    private String generateEmailBody(Vote vote) {
+        StringBuilder body = new StringBuilder();
+        body.append("Title: ").append(vote.getTitle()).append("\n");
+        body.append("Expire At: ").append(vote.getExpireAt()).append("\n\n");
+        body.append("Vote Results:\n");
+
+        List<VoteOption> voteOptions = vote.getVoteOptions();
+        for (VoteOption option : voteOptions) {
+            body.append(option.getRestaurant().getName()).append(": ")
+                    .append(option.getVoteResults().size()).append(" votes\n");
+        }
+
+        body.append("\nVoters:\n");
+        List<Voter> voters = vote.getVoters();
+        for (Voter voter : voters) {
+            body.append(voter.getNickname()).append("\n");
+        }
+
+        return body.toString();
     }
 }

--- a/src/main/java/capstone/restaurant/service/RestaurantService.java
+++ b/src/main/java/capstone/restaurant/service/RestaurantService.java
@@ -8,13 +8,11 @@ import capstone.restaurant.dto.tag.TagResponse;
 import capstone.restaurant.entity.Restaurant;
 import capstone.restaurant.entity.RestaurantTag;
 import capstone.restaurant.entity.Review;
-import capstone.restaurant.entity.Tag;
 import capstone.restaurant.repository.RestaurantRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,7 +31,7 @@ public class RestaurantService {
     }
 
     @Transactional
-    public RestaurantListResponse restaurantListFindByTag(String place , String[] tags , int page){
+    public RestaurantListResponse findRestaurantListByTag(String place , String[] tags , int page){
 
         RestaurantListResponse response = new RestaurantListResponse();
         response.setRestaurants(this.restaurantRepository.findRestaurantListByTag(place , tags , page));
@@ -41,7 +39,7 @@ public class RestaurantService {
     }
 
     @Transactional
-    public RestaurantListResponse restaurantListFindByKeyword(String keyword , Integer page){
+    public RestaurantListResponse findRestaurantListByKeyword(String keyword , Integer page){
         RestaurantListResponse response = new RestaurantListResponse();
 
         Page<Restaurant> restaurantList = this.restaurantRepository.findRestaurantsByNameContaining(keyword, PageRequest.of(page - 1 , 10));
@@ -73,7 +71,7 @@ public class RestaurantService {
     }
 
     @Transactional
-    public RestaurantResponse restaurantFindById(String restaurantId) {
+    public RestaurantResponse findRestaurantById(String restaurantId) {
 
         Restaurant restaurant = this.restaurantRepository.findByRestaurantHash(restaurantId);
 

--- a/src/main/java/capstone/restaurant/service/RestaurantService.java
+++ b/src/main/java/capstone/restaurant/service/RestaurantService.java
@@ -27,6 +27,11 @@ public class RestaurantService {
 
     private final RestaurantRepository restaurantRepository;
 
+    public RestaurantResponse findRandomRestaurant() {
+        Restaurant restaurant = restaurantRepository.findRandomRestaurant();
+        return convertRestaurantToRestaurantResponse(restaurant);
+    }
+
     @Transactional
     public RestaurantListResponse restaurantListFindByTag(String place , String[] tags , int page){
 

--- a/src/main/java/capstone/restaurant/service/RestaurantService.java
+++ b/src/main/java/capstone/restaurant/service/RestaurantService.java
@@ -25,9 +25,21 @@ public class RestaurantService {
 
     private final RestaurantRepository restaurantRepository;
 
+    @Transactional
+    public RestaurantResponse findRestaurantById(String restaurantId) {
+
+        Restaurant restaurant = this.restaurantRepository.findByRestaurantHash(restaurantId);
+
+        if(restaurant == null){
+            throw new EntityNotFoundException("해당 레스토랑을 찾을 수 없습니다");
+        }
+
+        return Restaurant.toDto(restaurant);
+    }
+
     public RestaurantResponse findRandomRestaurant() {
         Restaurant restaurant = restaurantRepository.findRandomRestaurant();
-        return convertRestaurantToRestaurantResponse(restaurant);
+        return Restaurant.toDto(restaurant);
     }
 
     @Transactional
@@ -68,33 +80,5 @@ public class RestaurantService {
 
         }
         return restaurantListSubs;
-    }
-
-    @Transactional
-    public RestaurantResponse findRestaurantById(String restaurantId) {
-
-        Restaurant restaurant = this.restaurantRepository.findByRestaurantHash(restaurantId);
-
-        if(restaurant == null){
-            throw new EntityNotFoundException("해당 레스토랑을 찾을 수 없습니다");
-        }
-
-        return convertRestaurantToRestaurantResponse(restaurant);
-    }
-
-    private RestaurantResponse convertRestaurantToRestaurantResponse(Restaurant restaurant){
-        List<TagResponse> tagResponseList = new ArrayList<TagResponse>();
-
-        for (RestaurantTag restaurantTag : restaurant.getRestaurantTag()) {
-            tagResponseList.add(new TagResponse(restaurantTag.getTag().getTagName() , restaurantTag.getTag().getTagCategory().getCategoryName()));
-        }
-
-        List<ReviewListSub> reviewList = new ArrayList<>();
-
-        for (Review review : restaurant.getReviews()){
-            reviewList.add(new ReviewListSub(review.getReview() , review.getIsAiReview()));
-        }
-
-        return new RestaurantResponse(restaurant.getName() , restaurant.getThumbnail() , tagResponseList , restaurant.getRestaurantHash() , reviewList);
     }
 }

--- a/src/main/java/capstone/restaurant/service/VoteService.java
+++ b/src/main/java/capstone/restaurant/service/VoteService.java
@@ -210,6 +210,7 @@ public class VoteService {
     }
 
     @Scheduled(fixedRate = 60000)
+    @Transactional
     public void sendResult() {
         LocalDateTime now = LocalDateTime.now();
         List<Vote> votes = voteRepository.findAll();

--- a/src/test/java/capstone/restaurant/RestaurantTest/RestaurantTest.java
+++ b/src/test/java/capstone/restaurant/RestaurantTest/RestaurantTest.java
@@ -11,22 +11,15 @@ import capstone.restaurant.repository.RestaurantTagRepository;
 import capstone.restaurant.repository.TagCategoryRepository;
 import capstone.restaurant.repository.TagRepository;
 import capstone.restaurant.service.RestaurantService;
-import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityNotFoundException;
-import org.aspectj.lang.annotation.After;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
-import javax.sql.DataSource;
-import java.lang.reflect.Array;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -90,7 +83,7 @@ public class RestaurantTest {
 
         String[] list  = {"맛있어요" , "넓어요"};
 
-        RestaurantListResponse response = restaurantService.restaurantListFindByTag(null, list, 1);
+        RestaurantListResponse response = restaurantService.findRestaurantListByTag(null, list, 1);
 
         Assertions.assertThat(response.getRestaurants().get(0).getRestaurantId()).isEqualTo("12");
 
@@ -106,8 +99,8 @@ public class RestaurantTest {
 
         restaurantRepository.saveAll(Arrays.asList(re));
 
-        RestaurantListResponse response1 = restaurantService.restaurantListFindByKeyword("ab" , 1);
-        RestaurantListResponse response2 = restaurantService.restaurantListFindByKeyword("ab" , 2);
+        RestaurantListResponse response1 = restaurantService.findRestaurantListByKeyword("ab" , 1);
+        RestaurantListResponse response2 = restaurantService.findRestaurantListByKeyword("ab" , 2);
 
         Assertions.assertThat(response1.getRestaurants().size()).isEqualTo(3);
         Assertions.assertThat(response2.getRestaurants().size()).isEqualTo(0);
@@ -134,7 +127,7 @@ public class RestaurantTest {
         restaurantRepository.save(restaurant1);
 
         Assertions.assertThatThrownBy(() -> {
-            restaurantService.restaurantFindById("12");
+            restaurantService.findRestaurantById("12");
         }).isInstanceOf(EntityNotFoundException.class);
     }
 
@@ -162,7 +155,7 @@ public class RestaurantTest {
         tagRepository.saveAll(Arrays.asList(tags));
         restaurantTagRepository.saveAll(Arrays.asList(restaurantTags));
 
-        RestaurantResponse restaurantResponse = restaurantService.restaurantFindById("13");
+        RestaurantResponse restaurantResponse = restaurantService.findRestaurantById("13");
 
         Assertions.assertThat(restaurant1.getRestaurantHash()).isEqualTo(restaurantResponse.getRestaurantId());
         Assertions.assertThat(restaurantResponse.getTags().get(0).getName()).isEqualTo(tag1.getTagName());


### PR DESCRIPTION
## 이슈
closes #62 

## 체크리스트
- [x] 투표 만료시 전송되는 이메일 내용 변경
- [x] 랜덤으로 식당을 뽑는 기능 구현

## 고민한 내용
### Transaction
vote 객체 안에 있는 voteOption과 voter 들을 lazy 로드 하려했는데 오류가 발생했다. 메서드에 Transactoonal 어노테이션을 추가하니 해결되었다.

### 랜덤한 식당 뽑기
데이터 베이스에 저장되어있는 식당 데이터중 랜덤한 데이터를 하나 뽑는 api를 구현했다. 이때 랜덤한 값을 어떻게 뽑을지 고민하다 mysql에 의존 하기로 했다.

```
SELECT * FROM Restaurant ORDER BY RANDOM() LIMIT 1
```

위와 같은 쿼리를 사용했다. mysql 내부에 랜덤으로 정렬하여 1개를 쿼리하는 방식이다. 이렇게 되면 쿼리 할 때 마다 랜덤으로 정렬되어 매번 다른 값이 쿼리된다.

하지만 데이터가 많을경우 쿼리 할 때 마다 데이터가 새롭게 정렬되어야해서 오버헤드가 발생할 수 있다. 아직 테스트 해보지 않았지만 많이 느려진다면 개선할 여지가 있다.

개선의 아이디어로는 데이터 id의 최고값을 가져오고 1 ~  최고값 사이의 랜덤한 값을 스프링에서 뽑아 한개를 쿼리하는 방법이다. 일단 이 방법을 사용하려면 모든 데이터가 순차적으로 들어있고 비어있는 데이터가 없어야한다는 전제 조건이 있긴하다.


### Refactoring
- 메서드 이름의 시작이 동사가 되도록 수정
- 엔티티 에서 dto 로 변경하는 로직을 엔티티로 옮겼다.